### PR TITLE
Support length controlled generation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,19 +11,7 @@ ATA lets you answer questions like: *Does an adversarial conversational strategy
 - Running ablation sweeps over parameters (e.g. `adversarial`, `num_turns`) to compare conditions
 - Using an optional LLM judge to score trajectory drift and identify key turning points
 
-### Ablation experiments
-
-The `--ablate` flag sweeps a cartesian product of any config parameters and runs experiments for each combination. For example, comparing adversarial vs. neutral mode on the Seattle-SF scenario shows a clear signal: adversarial conversations produced opinion change on all 4 survey questions (100% change rate), while neutral conversations produced change on 2 of 4 (50% change rate). The judge assessments capture *why* — adversarial personas pushed harder on identity and cost-of-living tradeoffs, while neutral personas converged on mutual respect without fully challenging the other's position.
-
-Results are written per-condition to `results/experiments/` with full config embedded for reproducibility.
-
----
-
-## Conversation Simulator
-
-The conversation simulator is the engine underneath ATA. It's a layered Python pipeline that handles the full experiment lifecycle.
-
-### Quick Start
+## Quick Start
 
 ```bash
 pip install -r requirements.txt

--- a/run.py
+++ b/run.py
@@ -11,11 +11,13 @@ Usage examples:
 
 import argparse
 import json
+import re
 import sys
 
 from dotenv import load_dotenv
 
 from simulator.experiments import AblationGrid, ExperimentConfig, ExperimentRunner
+from simulator.generator import ScenarioGenerator
 from simulator.scenarios import ScenarioNotFoundError, list_scenarios
 
 load_dotenv()
@@ -103,6 +105,19 @@ def build_parser() -> argparse.ArgumentParser:
             "Runs a full cartesian product of all specified values."
         ),
     )
+    parser.add_argument(
+        "--generate",
+        type=str,
+        default=None,
+        metavar="TOPIC",
+        help='Generate a new scenario from a topic description, e.g. --generate "remote work vs office"',
+    )
+    parser.add_argument(
+        "--topic",
+        type=str,
+        default=None,
+        help='Auto-generate the scenario from this topic before running experiments, e.g. --topic "vinyl vs streaming"',
+    )
 
     return parser
 
@@ -116,6 +131,8 @@ def print_config(args: argparse.Namespace, survey_questions) -> None:
     if args.model:
         print(f"Model:                {args.model}")
     print(f"Scenario:             {args.scenario}")
+    if args.topic:
+        print(f"Topic (auto-gen):     {args.topic}")
     print(f"Number of experiments:{args.num_experiments}")
     print(f"Turns per conversation:{args.num_turns}")
     print(f"Verbose mode:         {args.verbose}")
@@ -144,12 +161,28 @@ def main() -> int:
             print("No scenarios found in scenarios/ directory.")
         return 0
 
-    # Require --scenario for all other operations
-    if args.scenario is None:
-        parser.error("--scenario is required. Use --show-survey to list available scenarios.")
+    # --generate: create a new scenario and exit
+    if args.generate:
+        print(f"Generating scenario for: {args.generate}")
+        gen = ScenarioGenerator(provider=args.provider, model=args.model)
+        try:
+            path = gen.generate(args.generate)
+        except (ValueError, Exception) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        print(f"Scenario written to: {path}")
+        return 0
 
-    # Validate scenario name early so we can give a helpful error
-    if args.scenario not in available:
+    # Require --scenario for all other operations
+    if args.scenario is None and args.topic is None:
+        parser.error("--scenario is required (or use --topic to auto-generate). Use --show-survey to list available scenarios.")
+
+    # When --topic is provided without --scenario, derive a name from the topic
+    if args.topic and args.scenario is None:
+        args.scenario = re.sub(r"[^a-z0-9]+", "-", args.topic.lower()).strip("-")
+
+    # Validate scenario name early — but skip if we have a topic (it'll be generated)
+    if args.topic is None and args.scenario not in available:
         print(f"Error: unknown scenario {args.scenario!r}.", file=sys.stderr)
         if available:
             print("Available scenarios:", file=sys.stderr)
@@ -177,6 +210,7 @@ def main() -> int:
         verbose=args.verbose,
         debug=args.debug,
         judge=args.judge,
+        topic=args.topic,
     )
 
     # --ablate path

--- a/run.py
+++ b/run.py
@@ -118,6 +118,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help='Auto-generate the scenario from this topic before running experiments, e.g. --topic "vinyl vs streaming"',
     )
+    parser.add_argument(
+        "--max-tokens-per-turn",
+        type=int,
+        default=None,
+        help="Cap each conversation turn to at most N tokens (opt-in, e.g. 200 for ~150 word responses)",
+    )
 
     return parser
 
@@ -140,6 +146,8 @@ def print_config(args: argparse.Namespace, survey_questions) -> None:
     print(f"Debug mode:           {args.debug}")
     print(f"Survey questions:     {survey_questions if survey_questions else 'All questions'}")
     print(f"Judge mode:           {args.judge}")
+    if args.max_tokens_per_turn:
+        print(f"Max tokens/turn:      {args.max_tokens_per_turn}")
     if args.ablate:
         print(f"Ablation axes:        {args.ablate}")
     print(f"{sep}\n")
@@ -211,6 +219,7 @@ def main() -> int:
         debug=args.debug,
         judge=args.judge,
         topic=args.topic,
+        max_tokens_per_turn=args.max_tokens_per_turn,
     )
 
     # --ablate path

--- a/simulator/conversation.py
+++ b/simulator/conversation.py
@@ -27,6 +27,7 @@ def run(
     provider: Provider,
     tracker: UsageTracker,
     verbose: bool = False,
+    max_tokens_per_turn: Optional[int] = None,
 ) -> List[Turn]:
     """Run a conversation between two personas and return the list of Turns.
 
@@ -46,6 +47,7 @@ def run(
         provider:        Provider used for all API calls.
         tracker:         UsageTracker that records token usage.
         verbose:         If True, print each turn to stdout.
+        max_tokens_per_turn: If set, cap each API response to this many tokens.
 
     Returns:
         List of Turn objects with sequential turn_index values starting at 0.
@@ -68,6 +70,11 @@ def run(
         print(f"{'='*60}\n")
         print(f"{persona_a.name}: {initial_message}\n")
 
+    # Build optional kwargs for token-limited calls
+    call_kwargs = {}
+    if max_tokens_per_turn is not None:
+        call_kwargs["max_tokens"] = max_tokens_per_turn
+
     current_message = initial_message
 
     for exchange in range(num_turns):
@@ -78,6 +85,7 @@ def run(
             system_prompt=system_b,
             call_type="conversation",
             persona_name=persona_b.name,
+            **call_kwargs,
         )
         messages_b.append({"role": "assistant", "content": result_b.text})
 
@@ -93,6 +101,7 @@ def run(
             system_prompt=system_a,
             call_type="conversation",
             persona_name=persona_a.name,
+            **call_kwargs,
         )
         messages_a.append({"role": "assistant", "content": result_a.text})
 

--- a/simulator/experiments.py
+++ b/simulator/experiments.py
@@ -17,10 +17,11 @@ from itertools import product
 from typing import Any, Dict, List, Optional
 
 from simulator.conversation import Turn, run as run_conversation
+from simulator.generator import ScenarioGenerator
 from simulator.judge import JudgeResult, judge_conversation
 from simulator.personas import Persona
 from simulator.providers import get_provider
-from simulator.scenarios import load_scenario
+from simulator.scenarios import load_scenario, list_scenarios
 from simulator.survey import SurveyChange, SurveyResult, administer_survey, analyze_changes
 from simulator.tracking import UsageTracker
 
@@ -32,7 +33,11 @@ from simulator.tracking import UsageTracker
 
 @dataclass
 class ExperimentConfig:
-    """All parameters needed to reproduce a single experiment."""
+    """All parameters needed to reproduce a single experiment.
+
+    If *topic* is set and no YAML file exists for *scenario_name*, the
+    scenario is auto-generated from the topic before the first run.
+    """
 
     scenario_name: str
     provider: str = "anthropic"
@@ -43,6 +48,7 @@ class ExperimentConfig:
     verbose: bool = False
     debug: bool = False
     judge: bool = False
+    topic: Optional[str] = None          # auto-generate scenario from topic
 
 
 @dataclass
@@ -95,6 +101,16 @@ class ExperimentRunner:
     def __init__(self, config: ExperimentConfig) -> None:
         self.config = config
         self._experiment_counter = 0
+        self._ensure_scenario()
+
+    def _ensure_scenario(self) -> None:
+        """Auto-generate the scenario YAML if a topic is provided and the file doesn't exist."""
+        cfg = self.config
+        if cfg.topic and cfg.scenario_name not in list_scenarios():
+            print(f"  Generating scenario '{cfg.scenario_name}' from topic: {cfg.topic}")
+            gen = ScenarioGenerator(provider=cfg.provider, model=cfg.model)
+            path = gen.generate(cfg.topic, scenario_name=cfg.scenario_name)
+            print(f"  Scenario written to: {path}")
 
     # ------------------------------------------------------------------
     # Single run
@@ -312,7 +328,7 @@ class ExperimentRunner:
 # ---------------------------------------------------------------------------
 
 _ABLATABLE_FIELDS = frozenset(
-    {"num_turns", "adversarial", "provider", "scenario_name", "survey_questions", "model", "judge"}
+    {"num_turns", "adversarial", "provider", "scenario_name", "survey_questions", "model", "judge", "topic"}
 )
 
 

--- a/simulator/experiments.py
+++ b/simulator/experiments.py
@@ -49,6 +49,7 @@ class ExperimentConfig:
     debug: bool = False
     judge: bool = False
     topic: Optional[str] = None          # auto-generate scenario from topic
+    max_tokens_per_turn: Optional[int] = None  # opt-in: cap tokens per conversation turn
 
 
 @dataclass
@@ -152,7 +153,7 @@ class ExperimentRunner:
         )
 
         # Conversation
-        turns = run_conversation(
+        conv_kwargs = dict(
             persona_a=persona_a,
             persona_b=persona_b,
             initial_message=scenario.initial_message,
@@ -161,6 +162,9 @@ class ExperimentRunner:
             tracker=tracker,
             verbose=cfg.verbose,
         )
+        if cfg.max_tokens_per_turn is not None:
+            conv_kwargs["max_tokens_per_turn"] = cfg.max_tokens_per_turn
+        turns = run_conversation(**conv_kwargs)
 
         # Post-survey (with conversation context)
         conversation_context = _conversation_to_text(turns)
@@ -328,7 +332,7 @@ class ExperimentRunner:
 # ---------------------------------------------------------------------------
 
 _ABLATABLE_FIELDS = frozenset(
-    {"num_turns", "adversarial", "provider", "scenario_name", "survey_questions", "model", "judge", "topic"}
+    {"num_turns", "adversarial", "provider", "scenario_name", "survey_questions", "model", "judge", "topic", "max_tokens_per_turn"}
 )
 
 

--- a/simulator/generator.py
+++ b/simulator/generator.py
@@ -1,0 +1,190 @@
+"""
+simulator/generator.py — LLM-powered scenario generator.
+
+Uses the existing provider abstraction to generate complete scenario YAML
+files from a short topic description.
+
+Usage (standalone):
+    python -m simulator.generator "remote work vs office work"
+    python -m simulator.generator "cats vs dogs" --provider anthropic --output scenarios/cats-dogs.yaml
+
+Usage (as library):
+    from simulator.generator import ScenarioGenerator
+    gen = ScenarioGenerator(provider="anthropic")
+    gen.generate("remote work vs office work", output_path="scenarios/remote-office.yaml")
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from dotenv import load_dotenv
+
+from simulator.providers import get_provider
+
+load_dotenv()
+
+_SCENARIOS_DIR = Path("scenarios")
+
+_GENERATION_PROMPT = """\
+You are a scenario designer for a conversation simulation framework.
+
+Given a debate topic, generate a complete scenario YAML structure as a JSON object.
+The scenario simulates two personas having a conversation where one tries to
+persuade the other.
+
+Requirements:
+- "name": a short kebab-case slug derived from the topic (e.g. "remote-vs-office")
+- "persona_a": the persona who holds the initial position. Has "name" and "preference".
+- "persona_b": the opposing persona. Has "name" and "preference".
+- "persona_a_adversarial": same as persona_a (copy name and preference).
+- "persona_b_adversarial": has "name" and "strategy" — a detailed persuasion strategy
+  (3-5 sentences) for convincing persona_a to change their mind.
+- "survey": has "title" and "questions" (q1 through q4). Each question has a
+  "question" string and "options" with keys A, B, C, D ranging from strongly
+  favoring persona_a's position (A) to strongly favoring persona_b's position (D).
+- "initial_message": a 2-3 sentence opening message from persona_a expressing
+  their current position enthusiastically.
+
+Respond with ONLY a valid JSON object, no markdown fences, no commentary."""
+
+
+class ScenarioGenerator:
+    """Generate scenario YAML files from a topic description using an LLM."""
+
+    def __init__(
+        self,
+        provider: str = "anthropic",
+        model: Optional[str] = None,
+    ) -> None:
+        kwargs = {}
+        if model:
+            kwargs["model"] = model
+        self._provider = get_provider(provider, **kwargs)
+
+    def generate(
+        self,
+        topic: str,
+        output_path: Optional[str] = None,
+        scenario_name: Optional[str] = None,
+    ) -> Path:
+        """Generate a scenario YAML from a topic and write it to disk.
+
+        Parameters
+        ----------
+        topic:
+            A short description of the debate topic, e.g. "remote work vs office".
+        output_path:
+            Where to write the YAML. If None, derives from the generated/provided name.
+        scenario_name:
+            Force a specific scenario name (and filename). If None, the LLM picks one.
+
+        Returns
+        -------
+        Path to the written YAML file.
+        """
+        result = self._provider.call(
+            messages=[{"role": "user", "content": f"Topic: {topic}"}],
+            system_prompt=_GENERATION_PROMPT,
+            max_tokens=2048,
+        )
+
+        data = self._parse_response(result.text)
+        self._validate(data)
+
+        # Override the name if the caller specified one
+        if scenario_name:
+            data["name"] = scenario_name
+
+        if output_path is None:
+            name = data["name"]
+            _SCENARIOS_DIR.mkdir(parents=True, exist_ok=True)
+            output_path = _SCENARIOS_DIR / f"{name}.yaml"
+        else:
+            output_path = Path(output_path)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(output_path, "w", encoding="utf-8") as fh:
+            yaml.dump(data, fh, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+        return output_path
+
+    @staticmethod
+    def _parse_response(text: str) -> dict:
+        """Extract JSON from the LLM response, tolerating markdown fences."""
+        cleaned = text.strip()
+        # Strip markdown code fences if present
+        match = re.search(r"```(?:json)?\s*\n?(.*?)```", cleaned, re.DOTALL)
+        if match:
+            cleaned = match.group(1).strip()
+        try:
+            return json.loads(cleaned)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Failed to parse LLM response as JSON: {exc}\nResponse was:\n{text}"
+            ) from exc
+
+    @staticmethod
+    def _validate(data: dict) -> None:
+        """Ensure the generated data has all required fields."""
+        required = ("name", "persona_a", "persona_b", "survey", "initial_message")
+        for field in required:
+            if field not in data:
+                raise ValueError(f"Generated scenario is missing required field: {field!r}")
+
+        survey = data["survey"]
+        if "title" not in survey or "questions" not in survey:
+            raise ValueError("Survey must contain 'title' and 'questions'")
+
+        questions = survey["questions"]
+        if not questions:
+            raise ValueError("Survey must have at least one question")
+
+        for qid, q in questions.items():
+            if "question" not in q or "options" not in q:
+                raise ValueError(f"Survey question {qid!r} missing 'question' or 'options'")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a new scenario YAML from a topic description"
+    )
+    parser.add_argument("topic", help="Debate topic, e.g. 'remote work vs office work'")
+    parser.add_argument(
+        "--provider",
+        default="anthropic",
+        choices=["anthropic", "huggingface"],
+        help="LLM provider to use (default: anthropic)",
+    )
+    parser.add_argument("--model", default=None, help="Model override")
+    parser.add_argument(
+        "--output", "-o", default=None, help="Output path (default: scenarios/<name>.yaml)"
+    )
+
+    args = parser.parse_args()
+
+    print(f"Generating scenario for: {args.topic}")
+    gen = ScenarioGenerator(provider=args.provider, model=args.model)
+
+    try:
+        path = gen.generate(args.topic, output_path=args.output)
+    except (ValueError, Exception) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Scenario written to: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Supported length controlled generation

Noticed conversation responses grow in length over multiple turns -- this approach allows to control this this increasing response length to allow for experiments that are easier to parse and read

This bias for increased generation length is studied and described in the Length-Controlled AlpacaEval Paper: https://arxiv.org/abs/2404.04475

Example Usage: `python run.py --topic "move theatres vs streamimg" --num-experiments 1 --num-turns 3 --max-tokens-per-turn 34 --verbose`

Example Flag: `--max-tokens-per-turn 34`

Future work can include additional token constraints in generation and study how this influences preference drift.