### PR TITLE
feat: interview matching mode with mutual match decisions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ simulator/
   providers.py          # Anthropic / HuggingFace provider abstraction
   conversation.py       # Turn-taking conversation loop
   survey.py             # Survey administration and change analysis
+  decision.py           # End-of-conversation match decisions (interview mode)
   scenarios.py          # YAML scenario loader
   experiments.py        # ExperimentRunner and AblationGrid
   tracking.py           # Token usage tracker
@@ -189,6 +190,54 @@ Persona modes:
 - Simplified — set only `preference`
 - Full — set `background`, `personality`, `style`, `goals`
 - Adversarial — set `strategy`; selected when `--adversarial` flag is used
+
+### Interview / matching scenarios
+
+Set `mode: interview` to study a two-sided match instead of preference drift. The
+conversation is an interview between a **worker** (`persona_a`) and a **firm
+interviewer** (`persona_b`); at the end, **each agent independently decides whether
+it wants to match**. A match is mutual and binary — it happens only if *both* choose
+to match (as in deferred-acceptance matching markets). No survey is administered.
+
+Private information falls out naturally: each persona only sees its own system
+prompt, so any skills, criteria, or constraints you put in one persona's
+`background`/`goals` are hidden from the other and must be surfaced during the
+interview. Each side's decision hinges on what actually came out in conversation.
+
+```yaml
+name: my-interview
+mode: interview
+
+persona_a:                 # the worker / candidate (sends the opening message)
+  name: Jordan
+  background: "...skills + PRIVATE constraints the interviewer doesn't know..."
+  goals: "what you need in order to say yes"
+
+persona_b:                 # the firm interviewer / hiring manager
+  name: Riley
+  background: "...role + PRIVATE criteria the candidate doesn't know..."
+  goals: "what makes this candidate a match for you"
+
+# Optional — overrides the default role/match wording (see simulator/decision.py)
+decision:
+  worker_role: "the candidate interviewing for the role"
+  firm_role: "the hiring manager evaluating this candidate"
+  worker_match_meaning: "you would accept an offer to join this firm"
+  firm_match_meaning: "you would extend an offer to hire this candidate"
+
+initial_message: "Opening line from the worker..."
+```
+
+Run it like any scenario; the summary reports match rates instead of survey drift:
+
+```bash
+python run.py --scenario interview-swe --num-experiments 10 --num-turns 6 --verbose
+```
+
+Each result carries a `decision` object with the `worker_decision`, `firm_decision`
+(each `wants_match` + `reasoning`), and the `mutual_match` outcome. The batch summary
+reports `worker_match_rate`, `firm_match_rate`, `mutual_match_rate`, and
+`agreement_rate`. `interview-swe` ships as a worked example.
 
 ### Providers
 

--- a/run.py
+++ b/run.py
@@ -210,12 +210,24 @@ def main() -> int:
     print(f"\nResults written to: {output_path}")
 
     # Print a brief summary
-    sc = summary.get("survey_changes", {})
-    changed = sc.get("changed_answers", {})
     print(f"\nSummary: {summary['num_experiments']} experiments")
-    if changed:
-        print(f"  Mean changed answers per run: {changed.get('mean', 0):.2f}")
-        print(f"  Median: {changed.get('median', 0):.2f}  Stdev: {changed.get('stdev', 0):.2f}")
+
+    if "match_decisions" in summary:
+        md = summary["match_decisions"]
+
+        def _pct(x):
+            return "n/a" if x is None else f"{x * 100:.0f}%"
+
+        print(f"  Worker match rate: {_pct(md['worker_match_rate'])}")
+        print(f"  Firm match rate:   {_pct(md['firm_match_rate'])}")
+        print(f"  Mutual match rate: {_pct(md['mutual_match_rate'])}")
+        print(f"  Agreement rate:    {_pct(md['agreement_rate'])}")
+    else:
+        sc = summary.get("survey_changes", {})
+        changed = sc.get("changed_answers", {})
+        if changed:
+            print(f"  Mean changed answers per run: {changed.get('mean', 0):.2f}")
+            print(f"  Median: {changed.get('median', 0):.2f}  Stdev: {changed.get('stdev', 0):.2f}")
 
     return 0
 

--- a/scenarios/interview-swe.yaml
+++ b/scenarios/interview-swe.yaml
@@ -1,0 +1,67 @@
+name: interview-swe
+
+# Interview / matching scenario.
+#   mode: interview  -> no survey. The conversation is an interview, and at the
+#   end BOTH agents independently decide whether they want to MATCH. A match
+#   only happens if both choose to match (mutual, binary).
+#
+# Private information: each persona's "background/goals" contains criteria and
+# constraints the OTHER side does NOT see (each agent only receives its own
+# system prompt). The interview is where these must be surfaced, and each side's
+# final decision hinges on what actually came out in conversation.
+mode: interview
+
+# ---------------------------------------------------------------------------
+# persona_a = the WORKER / candidate (sends the opening message)
+# ---------------------------------------------------------------------------
+persona_a:
+  name: Jordan
+  background: >
+    A senior backend engineer with 7 years of experience building distributed
+    systems and payment infrastructure. Strong at reliability, on-call ownership,
+    and mentoring juniors. PRIVATE constraints the interviewer does not know up
+    front: you need at least two remote days per week for family caregiving, you
+    are not interested in a role that is mostly frontend work, and you are only
+    willing to move for a role with a credible path to Staff engineer within ~2 years.
+  personality: Thoughtful, direct, and candid. You ask pointed questions and dislike vague answers.
+  style: Professional but warm; you probe for specifics and push back politely when something is unclear.
+  goals: >
+    Determine whether this role offers (1) real technical ownership and growth toward
+    Staff, (2) at least two remote days per week, and (3) a backend-focused mandate.
+    You want to match only if the role genuinely fits these; you would rather pass
+    than accept a poor fit.
+
+# ---------------------------------------------------------------------------
+# persona_b = the FIRM interviewer / hiring manager
+# ---------------------------------------------------------------------------
+persona_b:
+  name: Riley
+  background: >
+    An engineering hiring manager at a fast-growing fintech startup, hiring a
+    senior backend engineer for the payments platform. The role is hybrid with an
+    expectation of ~3 days in office and a shared on-call rotation. PRIVATE criteria
+    the candidate does not know up front: you most need someone who will lead the
+    reliability / on-call effort and is comfortable with ambiguity and fast change;
+    you are wary of candidates who need a lot of structure or hand-holding; Staff
+    promotion is possible but typically takes 2-3 years and is not guaranteed.
+  personality: Energetic, mission-driven, and honest about tradeoffs. You sell the role but do not oversell.
+  style: Conversational and probing; you dig into how the candidate handles ownership, ambiguity, and on-call.
+  goals: >
+    Determine whether this candidate is senior enough to own reliability, thrives in
+    ambiguity, and will accept the hybrid + on-call reality. You want to match only
+    if they are a strong technical and cultural fit for how the team actually works.
+
+# ---------------------------------------------------------------------------
+# Match-decision framing (all fields optional; sensible defaults in decision.py)
+# ---------------------------------------------------------------------------
+decision:
+  worker_role: "the candidate (Jordan) interviewing for a senior backend engineer role"
+  firm_role: "the hiring manager (Riley) at the firm evaluating this candidate"
+  worker_match_meaning: "you would accept an offer to join this firm in this role"
+  firm_match_meaning: "you would extend an offer to hire this candidate for the role"
+
+initial_message: >
+  Hi Riley, thanks for taking the time to talk today. I've been looking forward to
+  learning more about the backend role on your payments platform — before we dive in,
+  I'd love to hear how you'd describe the team and what problem you're most hoping this
+  hire will take on.

--- a/simulator/decision.py
+++ b/simulator/decision.py
@@ -1,0 +1,241 @@
+"""
+simulator/decision.py — End-of-conversation match decisions for interviews.
+
+Unlike the LLM judge (Person C, a neutral outside analyst), the match decision
+is made *by each agent about itself*, in character. After an interview
+conversation, the worker (persona_a) and the firm interviewer (persona_b) each
+independently decide whether they want to MATCH — i.e. move forward together.
+
+A match is mutual and binary: it happens only if BOTH sides choose to match,
+mirroring two-sided matching markets (deferred acceptance). Each side decides
+privately, without seeing the other's decision.
+"""
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from simulator.conversation import Turn
+from simulator.personas import Persona
+from simulator.providers import Provider
+from simulator.tracking import UsageTracker
+
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable per-scenario via the YAML ``decision:`` block)
+# ---------------------------------------------------------------------------
+
+DEFAULT_WORKER_ROLE = "a candidate interviewing for a role at the firm"
+DEFAULT_FIRM_ROLE = "an interviewer at the firm evaluating the candidate"
+DEFAULT_WORKER_MATCH_MEANING = "you would accept an offer to join the firm in this role"
+DEFAULT_FIRM_MATCH_MEANING = "you would extend an offer to hire this candidate"
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MatchDecision:
+    persona_name: str
+    role: str
+    wants_match: Optional[bool]   # True / False, or None if the response failed to parse
+    reasoning: str
+
+
+@dataclass
+class MatchResult:
+    worker_decision: MatchDecision
+    firm_decision: MatchDecision
+    mutual_match: Optional[bool]  # True/False; None if either side failed to parse
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# Prompt builders
+# ---------------------------------------------------------------------------
+
+_DECISION_SYSTEM_PROMPT_TEMPLATE = """\
+You are {name}.
+{identity}
+
+Your role in this interview: {role}
+
+You have just finished an interview conversation with {counterpart}. Now, privately
+and independently, decide whether you want to MATCH with them — that is, whether
+{match_meaning}.
+
+Base your decision only on what you learned during this interview together with
+your own priorities, requirements, and constraints. Do not assume anything the
+other party did not actually convey. The other party is making their own decision
+separately and cannot see yours; a match only happens if BOTH of you choose to match.
+
+Respond with a JSON object and nothing else. No markdown fences, no text outside the JSON.
+
+Schema:
+{{
+  "wants_match": <true or false>,
+  "reasoning": "<one to three sentences explaining your decision>"
+}}
+"""
+
+
+def _persona_identity(persona: Persona) -> str:
+    """Summarise a persona's (possibly private) identity for the decision prompt."""
+    parts: List[str] = []
+    if persona.background:
+        parts.append(f"Background: {persona.background}")
+    if persona.personality:
+        parts.append(f"Personality: {persona.personality}")
+    if persona.goals:
+        parts.append(f"What you are looking for: {persona.goals}")
+    if persona.preference:
+        parts.append(f"Preference: {persona.preference}")
+    return "\n".join(parts) if parts else "(no additional details provided)"
+
+
+def _build_full_transcript(turns: List[Turn]) -> str:
+    """Format the entire conversation as readable ``Speaker: message`` lines."""
+    return "\n\n".join(f"{t.speaker}: {t.message}" for t in turns)
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+def _coerce_bool(value) -> Optional[bool]:
+    """Best-effort conversion of a JSON value to a bool. None if unrecognised."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in ("true", "yes", "match", "y", "1"):
+            return True
+        if v in ("false", "no", "reject", "pass", "n", "0"):
+            return False
+    return None
+
+
+def _parse_decision(raw: str, persona_name: str, role: str) -> MatchDecision:
+    text = raw.strip()
+    # strip markdown code fences if present (mirrors judge.py)
+    if text.startswith("```"):
+        text = text.split("```")[1]
+        if text.startswith("json"):
+            text = text[4:]
+        text = text.strip()
+
+    try:
+        data = json.loads(text)
+        wants = _coerce_bool(data["wants_match"])
+        if wants is None:
+            raise ValueError("unrecognised wants_match value")
+        return MatchDecision(
+            persona_name=persona_name,
+            role=role,
+            wants_match=wants,
+            reasoning=str(data.get("reasoning", "")),
+        )
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+        return MatchDecision(
+            persona_name=persona_name,
+            role=role,
+            wants_match=None,
+            reasoning=raw,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+def decide_match(
+    persona: Persona,
+    role: str,
+    counterpart_name: str,
+    match_meaning: str,
+    turns: List[Turn],
+    provider: Provider,
+    tracker: UsageTracker,
+) -> MatchDecision:
+    """Ask a single persona, in character, whether it wants to match.
+
+    Args:
+        persona:          The persona making the decision (its private info is used).
+        role:             Human-readable description of this persona's interview role.
+        counterpart_name: Name of the other party in the interview.
+        match_meaning:    What choosing to match means for this persona.
+        turns:            Full conversation transcript.
+        provider:         Provider used for the API call.
+        tracker:          UsageTracker that records token usage.
+
+    Returns:
+        MatchDecision with ``wants_match`` (None on parse failure) and reasoning.
+    """
+    system = _DECISION_SYSTEM_PROMPT_TEMPLATE.format(
+        name=persona.name,
+        identity=_persona_identity(persona),
+        role=role,
+        counterpart=counterpart_name,
+        match_meaning=match_meaning,
+    )
+    transcript = _build_full_transcript(turns)
+    user_message = (
+        f"Here is the full interview transcript:\n\n{transcript}\n\n"
+        f"Now make your private match decision as {persona.name}."
+    )
+
+    result = provider.call(
+        messages=[{"role": "user", "content": user_message}],
+        system_prompt=system,
+        max_tokens=512,
+        call_type="decision",
+        persona_name=persona.name,
+    )
+
+    return _parse_decision(result.text, persona.name, role)
+
+
+def collect_match_decisions(
+    persona_a: Persona,
+    persona_b: Persona,
+    turns: List[Turn],
+    provider: Provider,
+    tracker: UsageTracker,
+    worker_role: str = DEFAULT_WORKER_ROLE,
+    firm_role: str = DEFAULT_FIRM_ROLE,
+    worker_match_meaning: str = DEFAULT_WORKER_MATCH_MEANING,
+    firm_match_meaning: str = DEFAULT_FIRM_MATCH_MEANING,
+) -> MatchResult:
+    """Collect independent match decisions from the worker and the firm.
+
+    persona_a is treated as the worker/candidate; persona_b as the firm interviewer.
+    Each decides privately; ``mutual_match`` is True only if both choose to match.
+
+    Returns:
+        MatchResult bundling both decisions and the mutual outcome.
+    """
+    worker = decide_match(
+        persona_a, worker_role, persona_b.name, worker_match_meaning,
+        turns, provider, tracker,
+    )
+    firm = decide_match(
+        persona_b, firm_role, persona_a.name, firm_match_meaning,
+        turns, provider, tracker,
+    )
+
+    if worker.wants_match is None or firm.wants_match is None:
+        mutual: Optional[bool] = None
+    else:
+        mutual = worker.wants_match and firm.wants_match
+
+    return MatchResult(
+        worker_decision=worker,
+        firm_decision=firm,
+        mutual_match=mutual,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )

--- a/simulator/experiments.py
+++ b/simulator/experiments.py
@@ -17,10 +17,11 @@ from itertools import product
 from typing import Any, Dict, List, Optional
 
 from simulator.conversation import Turn, run as run_conversation
+from simulator.decision import MatchResult, collect_match_decisions
 from simulator.judge import JudgeResult, judge_conversation
 from simulator.personas import Persona
 from simulator.providers import get_provider
-from simulator.scenarios import load_scenario
+from simulator.scenarios import ScenarioConfig, load_scenario
 from simulator.survey import SurveyChange, SurveyResult, administer_survey, analyze_changes
 from simulator.tracking import UsageTracker
 
@@ -47,17 +48,22 @@ class ExperimentConfig:
 
 @dataclass
 class ExperimentResult:
-    """Self-describing result that embeds its full ExperimentConfig."""
+    """Self-describing result that embeds its full ExperimentConfig.
+
+    Survey fields are populated in survey mode; ``decision`` is populated in
+    interview mode. The two modes are mutually exclusive per run.
+    """
 
     experiment_id: int
     config: ExperimentConfig             # full config for self-describing results
     conversation: List[Turn]
-    pre_survey: SurveyResult
-    post_survey: SurveyResult
-    changes: List[SurveyChange]
-    tokens: Dict                         # input/output/total for this run
-    judge: Optional[JudgeResult]         # None unless cfg.judge == True
     timestamp: str
+    tokens: Optional[Dict] = None        # input/output/total for this run
+    pre_survey: Optional[SurveyResult] = None
+    post_survey: Optional[SurveyResult] = None
+    changes: Optional[List[SurveyChange]] = None
+    judge: Optional[JudgeResult] = None  # None unless cfg.judge == True
+    decision: Optional[MatchResult] = None  # populated in interview mode
 
 
 # ---------------------------------------------------------------------------
@@ -101,9 +107,11 @@ class ExperimentRunner:
     # ------------------------------------------------------------------
 
     def run_one(self) -> ExperimentResult:
-        """Execute one full experiment: pre-survey → conversation → post-survey.
+        """Execute one full experiment and return a self-describing ExperimentResult.
 
-        Returns an ExperimentResult with the full config embedded.
+        Dispatches on the scenario ``mode``:
+          - "survey"    → pre-survey → conversation → post-survey (preference drift)
+          - "interview" → conversation → both personas make a match decision
         """
         self._experiment_counter += 1
         exp_id = self._experiment_counter
@@ -121,6 +129,19 @@ class ExperimentRunner:
         # Load scenario (adversarial flag selects persona variants)
         scenario = load_scenario(cfg.scenario_name, adversarial=cfg.adversarial)
 
+        if scenario.mode == "interview":
+            return self._run_interview(exp_id, cfg, scenario, provider, tracker)
+        return self._run_survey(exp_id, cfg, scenario, provider, tracker)
+
+    def _run_survey(
+        self,
+        exp_id: int,
+        cfg: "ExperimentConfig",
+        scenario: ScenarioConfig,
+        provider: Any,
+        tracker: UsageTracker,
+    ) -> ExperimentResult:
+        """Preference-drift run: pre-survey → conversation → post-survey."""
         persona_a = scenario.persona_a
         persona_b = scenario.persona_b
 
@@ -188,6 +209,75 @@ class ExperimentRunner:
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
 
+    def _run_interview(
+        self,
+        exp_id: int,
+        cfg: "ExperimentConfig",
+        scenario: ScenarioConfig,
+        provider: Any,
+        tracker: UsageTracker,
+    ) -> ExperimentResult:
+        """Interview run: conversation → both personas make a private match decision."""
+        persona_a = scenario.persona_a
+        persona_b = scenario.persona_b
+
+        # Conversation
+        turns = run_conversation(
+            persona_a=persona_a,
+            persona_b=persona_b,
+            initial_message=scenario.initial_message,
+            num_turns=cfg.num_turns,
+            provider=provider,
+            tracker=tracker,
+            verbose=cfg.verbose,
+        )
+
+        # Match decisions — pull role/match wording from the scenario if provided
+        dblock = scenario.decision or {}
+        decision_kwargs = {
+            k: dblock[k]
+            for k in ("worker_role", "firm_role", "worker_match_meaning", "firm_match_meaning")
+            if k in dblock
+        }
+        match_result = collect_match_decisions(
+            persona_a, persona_b, turns, provider, tracker, **decision_kwargs
+        )
+
+        if cfg.verbose:
+            wd = match_result.worker_decision
+            fd = match_result.firm_decision
+            print(f"\n{'='*60}")
+            print("MATCH DECISIONS")
+            print(f"  {wd.persona_name} (worker): wants_match={wd.wants_match}")
+            print(f"  {fd.persona_name} (firm):   wants_match={fd.wants_match}")
+            print(f"  mutual_match={match_result.mutual_match}")
+            print(f"{'='*60}\n")
+
+        # Optional judge pass — still applies to the interview transcript
+        judge_result: Optional[JudgeResult] = None
+        if cfg.judge:
+            judge_result = judge_conversation(persona_a, persona_b, turns, provider, tracker)
+
+        token_summary = tracker.summary()
+        tokens = {
+            "input": token_summary["total_input_tokens"],
+            "output": token_summary["total_output_tokens"],
+            "total": token_summary["total_tokens"],
+        }
+
+        if cfg.debug:
+            tracker.export_csv()
+
+        return ExperimentResult(
+            experiment_id=exp_id,
+            config=cfg,
+            conversation=turns,
+            tokens=tokens,
+            judge=judge_result,
+            decision=match_result,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
     # ------------------------------------------------------------------
     # Batch run
     # ------------------------------------------------------------------
@@ -221,6 +311,10 @@ class ExperimentRunner:
                 "survey_changes": {},
                 "tokens": {"mean_input": 0, "mean_output": 0, "mean_total": 0},
             }
+
+        # Interview mode: summarise match decisions instead of survey drift
+        if any(r.decision is not None for r in results):
+            return self._summarize_interview(results)
 
         # Per-question change counts
         question_changed: Dict[str, int] = {}
@@ -264,6 +358,66 @@ class ExperimentRunner:
                     "mean": mean_changed,
                     "median": median_changed,
                     "stdev": stdev_changed,
+                },
+            },
+            "tokens": {
+                "mean_input": mean_input,
+                "mean_output": mean_output,
+                "mean_total": mean_total,
+            },
+        }
+
+    def _summarize_interview(self, results: List[ExperimentResult]) -> Dict:
+        """Summarise match-decision outcomes across interview runs.
+
+        Rates are computed over runs where the relevant decision(s) parsed
+        successfully; ``parse_errors`` counts runs dropped from a given rate.
+        """
+        n = len(results)
+        worker_yes = firm_yes = mutual_yes = 0
+        worker_n = firm_n = mutual_n = 0
+        agree_yes = agree_n = 0
+
+        for r in results:
+            d = r.decision
+            if d is None:
+                continue
+            w = d.worker_decision.wants_match
+            f = d.firm_decision.wants_match
+            if w is not None:
+                worker_n += 1
+                worker_yes += int(w)
+            if f is not None:
+                firm_n += 1
+                firm_yes += int(f)
+            if w is not None and f is not None:
+                mutual_n += 1
+                mutual_yes += int(w and f)
+                agree_n += 1
+                agree_yes += int(w == f)
+
+        def rate(num: int, den: int) -> Optional[float]:
+            return (num / den) if den else None
+
+        # Token aggregates
+        mean_input = statistics.mean(r.tokens["input"] for r in results)
+        mean_output = statistics.mean(r.tokens["output"] for r in results)
+        mean_total = statistics.mean(r.tokens["total"] for r in results)
+
+        return {
+            "num_experiments": n,
+            "match_decisions": {
+                "worker_match_rate": rate(worker_yes, worker_n),
+                "firm_match_rate": rate(firm_yes, firm_n),
+                "mutual_match_rate": rate(mutual_yes, mutual_n),
+                "agreement_rate": rate(agree_yes, agree_n),
+                "counts": {
+                    "worker_yes": worker_yes,
+                    "firm_yes": firm_yes,
+                    "mutual_yes": mutual_yes,
+                    "parseable_worker": worker_n,
+                    "parseable_firm": firm_n,
+                    "parseable_both": mutual_n,
                 },
             },
             "tokens": {

--- a/simulator/scenarios.py
+++ b/simulator/scenarios.py
@@ -57,8 +57,12 @@ class ScenarioConfig:
     name: str
     persona_a: Persona
     persona_b: Persona
-    survey: dict
     initial_message: str
+    # "survey" (default) → pre/post preference-drift survey on persona_a.
+    # "interview"        → no survey; both personas make a match decision at the end.
+    mode: str = "survey"
+    survey: Optional[dict] = None
+    decision: Optional[dict] = None    # interview role/match wording; see decision.py
     persona_a_adversarial: Optional[Persona] = None
     persona_b_adversarial: Optional[Persona] = None
 
@@ -100,8 +104,14 @@ def load_scenario(name: str, adversarial: bool = False) -> ScenarioConfig:
     with open(path, "r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh)
 
-    # Validate required fields
-    for field in ("name", "persona_a", "persona_b", "survey", "initial_message"):
+    mode = data.get("mode", "survey")
+
+    # Validate required fields. ``survey`` is required only in survey mode;
+    # interview mode measures a match decision instead.
+    required = ["name", "persona_a", "persona_b", "initial_message"]
+    if mode == "survey":
+        required.append("survey")
+    for field in required:
         if field not in data or data[field] is None:
             raise ScenarioValidationError(name, field)
 
@@ -120,8 +130,10 @@ def load_scenario(name: str, adversarial: bool = False) -> ScenarioConfig:
         name=data["name"],
         persona_a=persona_a,
         persona_b=persona_b,
-        survey=data["survey"],
         initial_message=data["initial_message"],
+        mode=mode,
+        survey=data.get("survey"),
+        decision=data.get("decision"),
         persona_a_adversarial=persona_a_adv,
         persona_b_adversarial=persona_b_adv,
     )

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -1,0 +1,132 @@
+"""
+Tests for simulator/decision.py — match-decision parsing and aggregation.
+
+These tests exercise pure parsing / bundling logic and the interview-mode
+summary; they do not make API calls.
+"""
+
+from simulator.conversation import Turn
+from simulator.decision import (
+    MatchDecision,
+    MatchResult,
+    _coerce_bool,
+    _parse_decision,
+    collect_match_decisions,
+)
+from simulator.personas import Persona
+
+
+# ---------------------------------------------------------------------------
+# _coerce_bool
+# ---------------------------------------------------------------------------
+
+def test_coerce_bool_native():
+    assert _coerce_bool(True) is True
+    assert _coerce_bool(False) is False
+
+
+def test_coerce_bool_strings():
+    assert _coerce_bool("true") is True
+    assert _coerce_bool("Yes") is True
+    assert _coerce_bool("no") is False
+    assert _coerce_bool("reject") is False
+
+
+def test_coerce_bool_unrecognised():
+    assert _coerce_bool("maybe") is None
+    assert _coerce_bool(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_decision
+# ---------------------------------------------------------------------------
+
+def test_parse_decision_plain_json():
+    d = _parse_decision('{"wants_match": true, "reasoning": "great fit"}', "Jordan", "worker")
+    assert d.wants_match is True
+    assert d.reasoning == "great fit"
+    assert d.persona_name == "Jordan"
+    assert d.role == "worker"
+
+
+def test_parse_decision_false():
+    d = _parse_decision('{"wants_match": false, "reasoning": "no remote days"}', "Jordan", "worker")
+    assert d.wants_match is False
+
+
+def test_parse_decision_markdown_fenced():
+    raw = '```json\n{"wants_match": true, "reasoning": "ok"}\n```'
+    d = _parse_decision(raw, "Riley", "firm")
+    assert d.wants_match is True
+
+
+def test_parse_decision_bad_json_becomes_none():
+    d = _parse_decision("I think yes but I'm not sure", "Jordan", "worker")
+    assert d.wants_match is None
+    assert d.reasoning == "I think yes but I'm not sure"
+
+
+def test_parse_decision_missing_key_becomes_none():
+    d = _parse_decision('{"reasoning": "forgot the field"}', "Jordan", "worker")
+    assert d.wants_match is None
+
+
+# ---------------------------------------------------------------------------
+# collect_match_decisions — mutual-match logic (with a stub provider)
+# ---------------------------------------------------------------------------
+
+class _StubResult:
+    def __init__(self, text):
+        self.text = text
+        self.input_tokens = 0
+        self.output_tokens = 0
+
+
+class _StubProvider:
+    """Returns a queued response per call, keyed by call order."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def call(self, messages, system_prompt, max_tokens=512, **kwargs):
+        text = self._responses[self.calls]
+        self.calls += 1
+        return _StubResult(text)
+
+
+def _turns():
+    return [
+        Turn(speaker="Jordan", message="hi", turn_index=0),
+        Turn(speaker="Riley", message="hello", turn_index=1),
+    ]
+
+
+def _run(worker_text, firm_text):
+    provider = _StubProvider([worker_text, firm_text])
+    return collect_match_decisions(
+        Persona(name="Jordan"),
+        Persona(name="Riley"),
+        _turns(),
+        provider,
+        tracker=None,
+    )
+
+
+def test_mutual_match_true_when_both_yes():
+    r = _run('{"wants_match": true, "reasoning": "a"}', '{"wants_match": true, "reasoning": "b"}')
+    assert isinstance(r, MatchResult)
+    assert r.worker_decision.wants_match is True
+    assert r.firm_decision.wants_match is True
+    assert r.mutual_match is True
+
+
+def test_mutual_match_false_when_one_says_no():
+    r = _run('{"wants_match": true, "reasoning": "a"}', '{"wants_match": false, "reasoning": "b"}')
+    assert r.mutual_match is False
+
+
+def test_mutual_match_none_on_parse_error():
+    r = _run('garbage', '{"wants_match": true, "reasoning": "b"}')
+    assert r.worker_decision.wants_match is None
+    assert r.mutual_match is None

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -37,3 +37,21 @@ def test_scenario_has_initial_message():
     config = load_scenario("seattle-sf")
     assert isinstance(config.initial_message, str)
     assert len(config.initial_message.strip()) > 0
+
+
+def test_survey_scenario_defaults_to_survey_mode():
+    config = load_scenario("seattle-sf")
+    assert config.mode == "survey"
+    assert config.decision is None
+
+
+def test_load_interview_scenario():
+    config = load_scenario("interview-swe")
+    assert config.mode == "interview"
+    assert config.survey is None          # interview scenarios need no survey
+    assert config.persona_a.name == "Jordan"
+    assert config.persona_b.name == "Riley"
+    assert config.initial_message.strip()
+    # decision block carries the role/match wording
+    assert config.decision is not None
+    assert "worker_role" in config.decision


### PR DESCRIPTION
Add an "interview" scenario mode to study a two-sided match between a worker (persona_a) and a firm interviewer (persona_b). After the multi-turn interview, each agent independently decides whether it wants to match; a match is mutual and binary (both must choose to match), mirroring deferred-acceptance matching markets. No survey is administered in this mode.

Private information is structural: each persona only sees its own system prompt, so skills/criteria/constraints placed on one side are hidden from the other and must be surfaced during the interview.

- simulator/decision.py: MatchDecision/MatchResult, in-character decision calls, robust JSON parsing, mutual-match aggregation
- scenarios.py: mode + decision block; survey optional in interview mode
- experiments.py: run_one dispatches survey vs interview; ExperimentResult gains optional decision field; summarize reports worker/firm/mutual/agreement rates
- run.py: prints match-rate summary for interview runs
- scenarios/interview-swe.yaml: worked SWE-candidate-vs-hiring-manager example
- tests: decision parsing/aggregation + interview scenario loading
- readme: interview mode docs